### PR TITLE
Fix previousInclude and previousExclude checks.

### DIFF
--- a/src/utils/emoji-index.js
+++ b/src/utils/emoji-index.js
@@ -55,9 +55,13 @@ function search(value, { emojisToShowFilter, maxResults, include, exclude, custo
 
     if ((include && include.length) || (exclude && exclude.length)) {
       pool = {}
-
-      if (previousInclude != include.sort().join(',') || previousExclude != exclude.sort().join(',')) {
+      
+      if (include && include.length && previousInclude != include.sort().join(',')) {
         previousInclude = include.sort().join(',')
+        index = {}
+      }
+      
+      if (exclude && exclude.length && previousExclude != exclude.sort().join(',')) {
         previousExclude = exclude.sort().join(',')
         index = {}
       }


### PR DESCRIPTION
The current implementation requires you to _always_ define `:include` AND `:exclude` for search to work. For example, if you do the following:

```
<picker
    set="apple"
    :emoji-size="16"
    :per-line="12"
    :exclude="['custom']"
    @click="addEmoji">
</picker>
```

Then attempt to search, you will receive the following JS error:

```
vendor.js:11692 Uncaught TypeError: Cannot read property 'sort' of undefined
    at Object.search (vendor.js:11692)
    at VueComponent.onInput (vendor.js:11532)
    at boundFn (vendor.js:93445)
    at HTMLInputElement.invoker (vendor.js:95018)
```

By doing the following, the error goes away:

```
<picker
    set="apple"
    :emoji-size="16"
    :per-line="12"
    :include="[]"
    :exclude="['custom']"
    @click="addEmoji">
</picker>
```

There is no reason to require the developer to have the empty `:include` just to get searching working. So this fix will break the checks apart for `previousInclude` and `previousExclude` to resolve this issue.