### PR TITLE
Added infinite scroll as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ import { Picker } from 'emoji-mart-vue'
 | **skin** | | `1` | Default skin color: `1, 2, 3, 4, 5, 6` |
 | **style** | | | Inline styles applied to the root element. Useful for positioning |
 | **title** | | `Emoji Mart™` | The title shown when no emojis are hovered |
+| **infiniteScroll** | | `true` | Scroll continuously through the categories |
 
 #### I18n
 ```js

--- a/src/components/picker.vue
+++ b/src/components/picker.vue
@@ -34,15 +34,30 @@
       :custom="customEmojis"
       :emoji-props="emojiProps">
     </category>
+    <template v-if="infiniteScroll">
+      <category
+        v-for="category in filteredCategories"
+        v-show="!searchEmojis"
+        ref="categories"
+        :key="category.name"
+        :i18n="i18n"
+        :emojis-to-show-filter="emojisToShowFilter"
+        :name="category.name"
+        :emojis="category.emojis"
+        :native="native"
+        :custom="customEmojis"
+        :emoji-props="emojiProps">
+      </category>
+    </template>
     <category
-      v-for="category in filteredCategories"
+      v-else-if="activeCategory"
       v-show="!searchEmojis"
       ref="categories"
-      :key="category.name"
+      :key="activeCategory.name"
       :i18n="i18n"
       :emojis-to-show-filter="emojisToShowFilter"
-      :name="category.name"
-      :emojis="category.emojis"
+      :name="activeCategory.name"
+      :emojis="activeCategory.emojis"
       :native="native"
       :custom="customEmojis"
       :emoji-props="emojiProps">
@@ -200,6 +215,10 @@ export default {
     hideCategoriesBar: {
       type: Boolean,
       default: false
+    },
+    infiniteScroll: {
+      type: Boolean,
+      default: true
     }
   },
   data() {
@@ -323,10 +342,12 @@ export default {
       if (this.searchEmojis) {
         this.onSearch(null)
         this.$refs.search.clear()
-        
+
         this.$nextTick(scrollToComponent)
-      } else {
+      } else if (this.infiniteScroll) {
         scrollToComponent()
+      } else {
+        this.activeCategory = this.categories[i];
       }
     },
     onSearch(emojis) {

--- a/src/components/picker.vue
+++ b/src/components/picker.vue
@@ -1,7 +1,7 @@
 <template>
 
 <div class="emoji-mart" :style="{ width: calculateWidth + 'px' }">
-  <div class="emoji-mart-bar">
+  <div class="emoji-mart-bar" v-if="!hideCategoriesBar">
     <anchors
       :i18n="i18n"
       :color="color"
@@ -12,6 +12,7 @@
   </div>
 
   <search
+    v-if="!hideSearchBar"
     ref="search"
     :i18n="i18n"
     :emojis-to-show-filter="emojisToShowFilter"
@@ -48,7 +49,7 @@
     </category>
   </div>
 
-  <div class="emoji-mart-bar">
+  <div class="emoji-mart-bar" v-if="!hidePreviewBar">
     <preview
       :title="title"
       :emoji="previewEmoji"
@@ -187,6 +188,18 @@ export default {
       default() {
         return I18N
       }
+    },
+    hidePreviewBar: {
+      type: Boolean,
+      default: false
+    },
+    hideSearchBar: {
+      type: Boolean,
+      default: false
+    },
+    hideCategoriesBar: {
+      type: Boolean,
+      default: false
     }
   },
   data() {

--- a/src/components/picker.vue
+++ b/src/components/picker.vue
@@ -296,11 +296,11 @@ export default {
     this.categories.push(CUSTOM_CATEGORY)
 
     this.categories[0].first = true
-    this.activeCategory = this.categories[0]
+    this.activeCategory = this.filteredCategories[0]
   },
   methods: {
     onScroll() {
-      if (!this.waitingForPaint) {
+      if (this.infiniteScroll && !this.waitingForPaint) {
         this.waitingForPaint = true
         window.requestAnimationFrame(this.onScrollPaint.bind(this))
       }


### PR DESCRIPTION
I found that loading all the emojis in one long scrollable div was affecting performance. So I made an option to disable infinity scroll, which means the user must click on a category to make it show. It works, and search still work, but I don't have the full overview of the code so I'm not sure if other areas are affected by this change.