### PR TITLE
Fix slowness on open destroy

### DIFF
--- a/src/components/picker/nimblePicker.vue
+++ b/src/components/picker/nimblePicker.vue
@@ -28,7 +28,7 @@
 
   <div class="emoji-mart-scroll" ref="scroll" @scroll="onScroll">
     <category
-      v-show="searchEmojis"
+      v-if="searchEmojis"
       :data="mutableData"
       :i18n="mutableI18n"
       id="search"
@@ -38,7 +38,7 @@
     />
     <category
       v-for="category in filteredCategories"
-      v-show="!searchEmojis && (infiniteScroll || category == activeCategory)"
+      v-if="!searchEmojis && (infiniteScroll || category == activeCategory)"
       ref="categories"
       :key="category.id"
       :data="mutableData"


### PR DESCRIPTION
I'm using the picker as a "popover" and it gets very slow on open and destroy as vue `destroy` needs to iterate over all the `nimble-emoji`. It's taking 2sec to close when infinite scrolling is active!

This is just a quick attempt to mitigate the problem replacing the `v-show` with `v-if`. Please note that by using `v-if` it turns the category click slower as the emojis need to be added to the DOM.

Another issue of the picker is that will multiple creations (using popover behaviour) it creates huge memory spikes and end up freezing the app for a couple of seconds due to GC being called. 

I've tried some virtual scroller libraries to reduce the number of items that are rendering at a particular time without success.

Leaving this PR as it will reduce the number of DOM elements created.