### PR TITLE
return data from uncompress method to fix issue #48

### DIFF
--- a/src/utils/data.js
+++ b/src/utils/data.js
@@ -101,6 +101,7 @@ const uncompress = (data) => {
 
     emoji.search = buildSearch(emoji)
   }
+  return data
 }
 
 module.exports = { buildSearch, compress, uncompress }


### PR DESCRIPTION
Issue https://github.com/jm-david/emoji-mart-vue/issues/48

In src/utils/emoji-index/nimble-emoji-index.js line 7, we assign the return value of the `uncompress(data)` call to the `data` variable. But the named function has no return value.

Because of this, the headless search is not functional. This quick fix should fix the issue.
